### PR TITLE
Improve Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ concept of Infinite Craft with different models and prompting strategies.
 
 ## Getting Started
 
-``` shell
+```shell
 git clone https://github.com/functorism/world-graph
 cd world-graph
 # optionally nix-shell
-sqlite3 db.sqlite < migrations/1_init_triples.sql
+sqlite3 db.sqlite < migrations/1_init_triple.sql
+# optionally run ollama in a Docker container
 docker-compose up -d
-cargo run
+DATABASE_URL=sqlite:db.sqlite cargo run
 ```
+
+If you are running Ollama yourself, make sure to `ollama pull neural-chat` first.


### PR DESCRIPTION
Fixed a typo in a filename and pointed out that running Ollama with `docker-compose` is optional (plus on a MacBook the Nvidia GPU requirement won't work).

Also added that `DATABASE_URL` needs to be provided when running the server.

I *think* there's one more thing missing for this to work out of the box with `docker-compose`, which is to make sure that the instance pulls the `neural-chat` image, but I left that out since I'm not sure and can't test.